### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,3 @@
+language = "python3"
+  run = ""
+  

--- a/README.md
+++ b/README.md
@@ -33,3 +33,4 @@ Python Modules:
 * PyGObject - Not included
 
 ### GTK3  (v3.30)
+[![Run on Repl.it](https://repl.it/badge/github/manuvarkey/GEstimator)](https://repl.it/github/manuvarkey/GEstimator)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).